### PR TITLE
Add Jest test for menuButton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "rolandhaden-github-io",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jest-environment-jsdom": "^30.0.2"
+  }
+}

--- a/tests/menuButton.test.js
+++ b/tests/menuButton.test.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('menuButton behavior', () => {
+  let myObject;
+  let ringClose;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="myObject"></div>
+      <div class="ringClose" style="visibility: hidden"></div>
+    `;
+    // Ensure fresh modules for each test
+    jest.resetModules();
+    myObject = document.getElementById('myObject');
+    ringClose = document.querySelector('.ringClose');
+    require('../menuButton.js');
+  });
+
+  test('click toggles active class and ringClose visibility', () => {
+    expect(myObject.classList.contains('active')).toBe(false);
+    expect(ringClose.style.visibility).toBe('hidden');
+
+    myObject.dispatchEvent(new Event('click'));
+    expect(myObject.classList.contains('active')).toBe(true);
+    expect(ringClose.style.visibility).toBe('visible');
+
+    myObject.dispatchEvent(new Event('click'));
+    expect(myObject.classList.contains('active')).toBe(false);
+    expect(ringClose.style.visibility).toBe('hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with jsdom environment
- ignore node dependencies
- test that clicking `#myObject` toggles active class and ring visibility

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862a952ed808332808d17f29801195e