### PR TITLE
Sort GitHub repos by update time

### DIFF
--- a/github.js
+++ b/github.js
@@ -2,6 +2,9 @@ document.addEventListener("DOMContentLoaded", () => {
   fetch("https://api.github.com/users/RolandHaden/repos")
     .then((response) => response.json())
     .then((data) => {
+      // Sort repositories by most recently updated
+      data.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+
       const reposArray = data.map((repo) => ({
         name: repo.name,
         html_url: repo.html_url,


### PR DESCRIPTION
## Summary
- sort fetched repositories by `updated_at` to show newest projects first

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862b09ea55483328e3a6dddecab8e1d